### PR TITLE
LineChartData isEnableCache added

### DIFF
--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -59,16 +59,17 @@ class LineChartData extends AxisChartData with EquatableMixin {
     super.baselineY,
     super.clipData = const FlClipData.none(),
     super.backgroundColor,
+    bool isEnableCache = false,
   }) : super(
           touchData: lineTouchData,
           minX:
-              minX ?? LineChartHelper.calculateMaxAxisValues(lineBarsData).minX,
+              minX ?? LineChartHelper.calculateMaxAxisValues(lineBarsData, isEnableCache: isEnableCache).minX,
           maxX:
-              maxX ?? LineChartHelper.calculateMaxAxisValues(lineBarsData).maxX,
+              maxX ?? LineChartHelper.calculateMaxAxisValues(lineBarsData, isEnableCache: isEnableCache).maxX,
           minY:
-              minY ?? LineChartHelper.calculateMaxAxisValues(lineBarsData).minY,
+              minY ?? LineChartHelper.calculateMaxAxisValues(lineBarsData, isEnableCache: isEnableCache).minY,
           maxY:
-              maxY ?? LineChartHelper.calculateMaxAxisValues(lineBarsData).maxY,
+              maxY ?? LineChartHelper.calculateMaxAxisValues(lineBarsData, isEnableCache: isEnableCache).maxY,
         );
 
   /// [LineChart] draws some lines in various shapes and overlaps them.

--- a/lib/src/chart/line_chart/line_chart_helper.dart
+++ b/lib/src/chart/line_chart/line_chart_helper.dart
@@ -11,15 +11,16 @@ class LineChartHelper {
       _cachedResults = {};
 
   static LineChartMinMaxAxisValues calculateMaxAxisValues(
-    List<LineChartBarData> lineBarsData,
-  ) {
+    List<LineChartBarData> lineBarsData, {
+    bool isEnableCache = true,
+  }) {
     if (lineBarsData.isEmpty) {
       return const LineChartMinMaxAxisValues(0, 0, 0, 0);
     }
 
     final listWrapper = lineBarsData.toWrapperClass();
 
-    if (_cachedResults.containsKey(listWrapper)) {
+    if (isEnableCache && _cachedResults.containsKey(listWrapper)) {
       return _cachedResults[listWrapper]!.copyWith(readFromCache: true);
     }
 
@@ -69,7 +70,9 @@ class LineChartHelper {
     }
 
     final result = LineChartMinMaxAxisValues(minX, maxX, minY, maxY);
-    _cachedResults[listWrapper] = result;
+    if (isEnableCache) {
+      _cachedResults[listWrapper] = result;
+    }
     return result;
   }
 }


### PR DESCRIPTION
Fixes memory leak in LineChartHelper

- done by adding a flag isEnableCache into LineChartData class
- by default LineChartData healper cache is disabled now